### PR TITLE
Update 'Productivity Enhancers: Text Editors'

### DIFF
--- a/index.html
+++ b/index.html
@@ -1397,7 +1397,7 @@ $ ./a.out</code></pre>
                                                   <p><strong>Computer: 13-inch MacBook Pro</strong><br> Widely rated as having best-in-class hardware, these machines are capable of running Mac as well as Windows and Linux operating systems.
                                                   <br><img src="images/sec2_macbook.jpg"></p>
                          </div><div class="productive">
-                                                  <p><strong>Text editor: Highly subjective</strong><br> Developers use scores of different text editors, programs that allow them to more easily write and debug code. Favorites include Sublime Text, Text Wrangler, and Brackets.
+                                                  <p><strong>Text editor: Highly subjective</strong><br> Developers use scores of different text editors, programs that allow them to more easily write and debug code. Favorites include Sublime Text, Vim, and Emacs.
                                                   <br><img src="images/sec2_sublime.jpg"></p>
                          </div><div class="productive">
                                                   <p><strong>Old-school desk: The Jerker</strong><br> Nerds in countless online forums pine after this discontinued modular Ikea workstation, which allows a user to customize desk and shelf height. It sells for about $250 on EBay.


### PR DESCRIPTION
Brackets and TextWrangler are usually not widely used enough to justify being called "favorites", I think. Vim and Emacs certainly deserve to be called "favorites", though.

I tried to do some research on what text editors actually have the most adoption, but I could hardly find any studies or blog posts. http://www.sitepoint.com/editor-rubyists-use/ is admittedly Ruby specific, but shows Vim, Emacs, and Sublime as the top spots, which is what I would have guessed off the top of my head. Thus, I updated the copy to include Vim and Emacs.
